### PR TITLE
Add Clientside Mod Menu badge

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,5 +24,8 @@
   },
   "mixins": [
     "armor-visibility.mixins.json"
-  ]
+  ],
+  "custom": {
+  "modmenu:clientsideOnly": true
+  }
 }


### PR DESCRIPTION
The mod  is client-side only, and the [ModMenu ](https://www.curseforge.com/minecraft/mc-mods/modmenu) badge looks nice. 