### PR TITLE
Handle Cloak Offset when the Chestplate is not Visible

### DIFF
--- a/common/src/main/java/com/diontryban/armor_visibility/client/ArmorVisibilityClient.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/client/ArmorVisibilityClient.java
@@ -35,8 +35,6 @@ import net.minecraft.world.entity.player.Player;
 import org.lwjgl.glfw.GLFW;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.io.File;
-
 public class ArmorVisibilityClient {
     private static final KeyMapping KEY = KeyMappingRegistry.registerKeyMapping(
             new ResourceLocation(ArmorVisibility.MOD_ID, "armor_visibility_toggle"),
@@ -92,15 +90,19 @@ public class ArmorVisibilityClient {
     }
 
     public static void maybeCancelRender(LivingEntity livingEntity, CallbackInfo ci) {
+        maybeCancelRender(livingEntity, ci::cancel);
+    }
+
+    public static void maybeCancelRender(LivingEntity livingEntity, Runnable onCancel) {
         if (ArmorVisibility.OPTIONS.get().playersOnly && !(livingEntity instanceof Player)) {
             return;
         }
 
         if (hideAllArmor) {
-            ci.cancel();
+            onCancel.run();
         } else if (hideMyArmor) {
             if (livingEntity.equals(Minecraft.getInstance().player)) {
-                ci.cancel();
+                onCancel.run();
             }
         }
     }

--- a/common/src/main/java/com/diontryban/armor_visibility/mixin/client/PlayerModelMixin.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/mixin/client/PlayerModelMixin.java
@@ -1,0 +1,36 @@
+package com.diontryban.armor_visibility.mixin.client;
+
+import com.diontryban.armor_visibility.ArmorVisibility;
+import com.diontryban.armor_visibility.client.ArmorVisibilityClient;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerModel.class)
+public abstract class PlayerModelMixin {
+
+    @Final
+    @Shadow
+    private ModelPart cloak;
+
+    @Inject(at = @At("TAIL"), method = "setupAnim(Lnet/minecraft/world/entity/LivingEntity;FFFFF)V")
+    public void setupCloakAnim(LivingEntity entity, float walkPosition, float walkSpeed, float bob, float yRotation, float xRotation, CallbackInfo ci) {
+        if (ArmorVisibility.OPTIONS.get().togglesChestplate) { // Check if the chestplate can be toggled
+            ArmorVisibilityClient.maybeCancelRender(entity, () -> { // If the armor is hidden, change cloak location
+                if (entity.isCrouching()) {
+                    this.cloak.z = 1.4F;
+                    this.cloak.y = 1.85F;
+                } else {
+                    this.cloak.z = 0.0F;
+                    this.cloak.y = 0.0F;
+                }
+            });
+        }
+    }
+}

--- a/common/src/main/resources/armor_visibility.mixins.json
+++ b/common/src/main/resources/armor_visibility.mixins.json
@@ -10,7 +10,8 @@
         "client.CapeLayerMixin",
         "client.CustomHeadLayerMixin",
         "client.ElytraLayerMixin",
-        "client.HumanoidArmorLayerMixin"
+        "client.HumanoidArmorLayerMixin",
+        "client.PlayerModelMixin"
     ],
     "injectors": {
       "defaultRequire": 1


### PR DESCRIPTION
Closes #13

Sets the cloak y/z when the chestplate is not visible but is on the player.