### PR TITLE
Add inverse keybind option in config

### DIFF
--- a/common/src/main/java/com/diontryban/armor_visibility/client/ArmorVisibilityClient.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/client/ArmorVisibilityClient.java
@@ -71,7 +71,7 @@ public class ArmorVisibilityClient {
             } else {
                 player.playSound(SoundEvents.TRIPWIRE_CLICK_ON, 0.5f, 1.0f);
 
-                if (player.isShiftKeyDown() != options.get().inverse_keybind) {
+                if (player.isShiftKeyDown() != ArmorVisibility.OPTIONS.get().inverseKeybind) {
                     hideAllArmor = true;
 
                     player.displayClientMessage(Component.translatable(

--- a/common/src/main/java/com/diontryban/armor_visibility/client/ArmorVisibilityClient.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/client/ArmorVisibilityClient.java
@@ -71,7 +71,7 @@ public class ArmorVisibilityClient {
             } else {
                 player.playSound(SoundEvents.TRIPWIRE_CLICK_ON, 0.5f, 1.0f);
 
-                if (player.isShiftKeyDown()) {
+                if (player.isShiftKeyDown() != options.get().inverse_keybind) {
                     hideAllArmor = true;
 
                     player.displayClientMessage(Component.translatable(

--- a/common/src/main/java/com/diontryban/armor_visibility/client/gui/screens/ArmorVisibilityOptionsScreen.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/client/gui/screens/ArmorVisibilityOptionsScreen.java
@@ -60,8 +60,8 @@ public class ArmorVisibilityOptionsScreen extends ModOptionsScreen<ArmorVisibili
         this.list.addBig(OptionInstance.createBoolean(
                 "armor_visibility.options.inverse_keybind",
                 value -> Tooltip.create(Component.translatable("armor_visibility.options.inverse_keybind.tooltip")),
-                options.get().inverse_keybind,
-                value -> options.get().inverse_keybind = value
+                options.get().inverseKeybind,
+                value -> options.get().inverseKeybind = value
         ));
 
         this.list.addSmall(

--- a/common/src/main/java/com/diontryban/armor_visibility/client/gui/screens/ArmorVisibilityOptionsScreen.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/client/gui/screens/ArmorVisibilityOptionsScreen.java
@@ -57,6 +57,13 @@ public class ArmorVisibilityOptionsScreen extends ModOptionsScreen<ArmorVisibili
                 value -> options.get().playersOnly = value
         ));
 
+        this.list.addBig(OptionInstance.createBoolean(
+                "armor_visibility.options.inverse_keybind",
+                value -> Tooltip.create(Component.translatable("armor_visibility.options.inverse_keybind.tooltip")),
+                options.get().inverse_keybind,
+                value -> options.get().inverse_keybind = value
+        ));
+
         this.list.addSmall(
                 OptionInstance.createBoolean(
                         "armor_visibility.options.toggles_helmet",

--- a/common/src/main/java/com/diontryban/armor_visibility/options/ArmorVisibilityOptions.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/options/ArmorVisibilityOptions.java
@@ -29,6 +29,8 @@ public class ArmorVisibilityOptions extends ModOptions {
     public boolean keepCapeVisible = true;
     @SerializedName("players_only")
     public boolean playersOnly = true;
+    @SerializedName("inverse_keybind")
+    public boolean inverseKeybind = true;
 
     @SerializedName("toggles_helmet")
     public boolean togglesHelmet = true;

--- a/common/src/main/java/com/diontryban/armor_visibility/options/ArmorVisibilityOptions.java
+++ b/common/src/main/java/com/diontryban/armor_visibility/options/ArmorVisibilityOptions.java
@@ -30,7 +30,7 @@ public class ArmorVisibilityOptions extends ModOptions {
     @SerializedName("players_only")
     public boolean playersOnly = true;
     @SerializedName("inverse_keybind")
-    public boolean inverseKeybind = true;
+    public boolean inverseKeybind = false;
 
     @SerializedName("toggles_helmet")
     public boolean togglesHelmet = true;

--- a/common/src/main/resources/assets/armor_visibility/lang/en_us.json
+++ b/common/src/main/resources/assets/armor_visibility/lang/en_us.json
@@ -12,6 +12,8 @@
     "armor_visibility.options.keep_cape_visible.tooltip": "Keep player capes visible when armor is toggled hidden.",
     "armor_visibility.options.players_only": "Only Affect Players",
     "armor_visibility.options.players_only.tooltip": "Don't change the visibility of armor on mobs (armor stands, zombies, etc.).",
+    "armor_visibility.options.inverse_keybind": "Inverse keybind",
+    "armor_visibility.options.inverse_keybind.tooltip": "If on, shift-action of keybind will be swapped with main.",
 
     "armor_visibility.options.toggles_helmet": "Toggles Helmet",
     "armor_visibility.options.toggles_helmet.tooltip": "If on, toggling armor visibility toggles the visibility of helmets.",


### PR DESCRIPTION
This option swaps shift action and main action of keybind.

I think people want to hide other's armor more than their own. So it would make sense for main keybind action to hide all armor.

I also have a [branch](https://github.com/CaptainSqrBeard/armor-visibility/tree/edit) where keybind just cycle between all three states to be more intuitive.